### PR TITLE
Some fixes related to the recent "toc-entry" changes

### DIFF
--- a/src/obfl-specification.html
+++ b/src/obfl-specification.html
@@ -1180,7 +1180,8 @@ information.</p>
 <div class="sidebar">
 <dl>
   <dt>Usage</dt>
-    <dd class="markup">before, after, field, toc-entry, block, item, style</dd>
+    <dd class="markup">before, after, field, toc-entry, toc-entry-on-resumed,
+    block, item, style</dd>
   <dt>Attributes</dt>
     <dd><dl>
         <dt>expression [required]</dt>
@@ -1210,7 +1211,7 @@ the current row.</p>
 <div class="sidebar markup">
 <dl>
   <dt>Usage</dt>
-    <dd>before, after, toc-entry, block, item</dd>
+    <dd>before, after, toc-entry, toc-entry-on-resumed, block, item</dd>
   <dt>Attributes</dt>
     <dd><dl>
         <dt>align [optional]</dt>
@@ -1239,7 +1240,7 @@ refered to in headers and footers.</p>
 <div class="sidebar markup">
 <dl>
   <dt>Usage</dt>
-    <dd>before, after, toc-entry, block, item</dd>
+    <dd>before, after, toc-entry, toc-entry-on-resumed, block, item</dd>
   <dt>Attributes</dt>
     <dd><dl>
         <dt>class [required]</dt>
@@ -1282,7 +1283,7 @@ paragraph).</p>
 <div class="sidebar markup">
 <dl>
   <dt>Usage</dt>
-    <dd>before, after, toc-entry, block, item</dd>
+    <dd>before, after, toc-entry, toc-entry-on-resumed, block, item</dd>
   <dt>Content Model</dt>
     <dd>Empty.</dd>
 </dl>
@@ -1296,7 +1297,7 @@ element.</p>
 <div class="sidebar markup">
 <dl>
   <dt>Usage</dt>
-    <dd>before, after, toc-entry, block, item, style</dd>
+    <dd>before, after, toc-entry, toc-entry-on-resumed, block, item, style</dd>
   <dt>Attributes</dt>
     <dd><dl>
         <dt>ref-id [required]</dt>
@@ -1319,7 +1320,7 @@ language is different from the surrounding text.</p>
 <div class="sidebar markup">
 <dl>
   <dt>Usage</dt>
-    <dd>before, after, toc-entry, block, item</dd>
+    <dd>before, after, toc-entry, toc-entry-on-resumed, block, item</dd>
   <dt>Attributes</dt>
     <dd><dl>
         <dt>xml:lang [optional]</dt>
@@ -1351,7 +1352,7 @@ emphasis or strong.</p>
 <div class="sidebar markup">
 <dl>
   <dt>Usage</dt>
-    <dd>before, after, toc-entry, block, item, span, style</dd>
+    <dd>before, after, toc-entry, toc-entry-on-resumed, block, item, span, style</dd>
   <dt>Attributes</dt>
     <dd><dl>
         <dt>name [required]</dt>
@@ -2052,8 +2053,7 @@ positioned elements, such as footnotes.</p>
 <h4 id="L1210" class="include">item</h4>
 
 <p>Defines the formatting of an item that should be inserted somewhere in the
-flow. The behavior of this element is similar to the toc-entry element, except
-that nesting of items is not allowed.</p>
+flow. The behavior of this element is similar to the toc-entry element.</p>
 
 <div class="sidebar markup">
 <dl>


### PR DESCRIPTION
- "Usage" of elements allowed inside `toc-entry` was not updated to also be allowed inside `toc-entry-on-resumed`
- Nesting of toc-entry is not allowed anymore, so don't say so under description of `item`.

@PaulRambags @kalaspuffar