### PR TITLE
Issue/15

### DIFF
--- a/src/obfl-specification.html
+++ b/src/obfl-specification.html
@@ -1193,11 +1193,6 @@ information.</p>
         <dt>text-style [optional]</dt>
           <dd>A text style, e.g. emphasis or strong</dd>
           <dd class="markup note">This attribute is only available in the context of a field element.</dd>
-        <dt>number-format [optional]</dt>
-          <dd>One of 'default', 'roman', 'upper-roman', 'lower-roman',
-            'upper-alpha', 'lower-alpha'.</dd>
-          <dd class="markup note">This attribute may only be used when the
-            expression evaluates to a numeric value.</dd>
       </dl>
     </dd>
   <dt>Content Model</dt>

--- a/src/validation/obfl.rng
+++ b/src/validation/obfl.rng
@@ -782,7 +782,7 @@
     </element>
   </define>
   <define name="attlist-evaluate-in-field" combine="interleave">
-    <ref name="attlist-evaluate"/>
+    <attribute name="expression"/>
     <optional>
       <attribute name="text-style">
         <data type="NMTOKEN"/>

--- a/src/validation/obfl.rng
+++ b/src/validation/obfl.rng
@@ -782,7 +782,7 @@
     </element>
   </define>
   <define name="attlist-evaluate-in-field" combine="interleave">
-    <attribute name="expression"/>
+    <ref name="attlist-evaluate"/>
     <optional>
       <attribute name="text-style">
         <data type="NMTOKEN"/>

--- a/src/validation/obfl.rng
+++ b/src/validation/obfl.rng
@@ -788,9 +788,6 @@
         <data type="NMTOKEN"/>
       </attribute>
     </optional>
-    <optional>
-      <ref name="number-format-attribute"/>
-    </optional>
   </define>
   <define name="evaluate">
     <element name="evaluate">
@@ -800,9 +797,6 @@
   </define>
   <define name="attlist-evaluate" combine="interleave">
     <attribute name="expression"/>
-    <optional>
-      <ref name="number-format-attribute"/>
-    </optional>
   </define>
   <define name="table-of-contents">
     <element name="table-of-contents">


### PR DESCRIPTION
Closes #15.

The optional `number-format` attribute was removed from the `evaluate` element.
Certain improvements have been made in `obfl.rng`.

@kalaspuffar @bertfrees Please review this pull request.