### PR TITLE
Metadata tag

### DIFF
--- a/src/obfl-specification.html
+++ b/src/obfl-specification.html
@@ -6,7 +6,7 @@
   <meta name="dc:identifier" content="" />
   <meta name="dc:Title" content="OBFL Specification" />
   <meta name="dc:Language" content="en" />
-  <meta name="dc:Date" content="2019-12-02" />
+  <meta name="dc:Date" content="2020-04-29" />
   <link rel="stylesheet" href="styles/w3c-unofficial.css" type="text/css" />
   <link rel="stylesheet" href="styles/style.css" type="text/css" />
 </head>
@@ -1167,7 +1167,7 @@ should be excluded entirely.</p>
       </dl>
     </dd>
   <dt>Content Model</dt>
-    <dd>text(), leader, marker, br, evaluate, page-number, marker-reference,
+    <dd>text(), leader, marker, br, evaluate, page-number, metadata, marker-reference,
       span, style, anchor, block, table, xml-data [0 or more]</dd>
 </dl>
 </div>
@@ -1313,6 +1313,29 @@ element.</p>
         <dt>number-format [optional]</dt>
           <dd>One of 'default', 'roman', 'upper-roman', 'lower-roman',
             'upper-alpha', 'lower-alpha'.</dd>
+      </dl>
+    </dd>
+  <dt>Content Model</dt>
+    <dd>Empty.</dd>
+</dl>
+</div>
+
+<h4 id="L840" class="include">metadata</h4>
+
+<ins datetime="20200429T15:00:00">The metadata attribute can be added to any block in order
+  to send information through the dotify framework from obfl to pef.</ins>
+
+<p>The metadata element is used to add information.</p>
+
+<div class="sidebar markup">
+<dl>
+  <dt>Usage</dt>
+    <dd>block</dd>
+  <dt>Attributes</dt>
+    <dd>
+      <dl>
+        <dt>any attribute [optional]</dt>
+          <dd></dd>
       </dl>
     </dd>
   <dt>Content Model</dt>

--- a/src/obfl-specification.html
+++ b/src/obfl-specification.html
@@ -1322,10 +1322,11 @@ element.</p>
 
 <h4 id="L840" class="include">external-reference</h4>
 
-<ins datetime="20200429T15:00:00">The external-reference element can be attached to any position in the text within the block
-  to send information through the dotify framework from obfl to pef.</ins>
+<ins datetime="20200429T15:00:00">The external-reference element can be attached to any position in the text
+  within the block to send information through the implementation from obfl to pef.</ins>
 
-<p>The external-reference element is used to add information.</p>
+<p>With the external-reference element custom annotations can be attached to any position in the text within
+  a block or field. How the user agent processes the information is implementation dependent.</p>
 
 <div class="sidebar markup">
 <dl>
@@ -1341,6 +1342,32 @@ element.</p>
   <dt>Content Model</dt>
     <dd>Empty.</dd>
 </dl>
+</div>
+
+<h5 id="L1331">Example</h5>
+<p>A typical use case is to pass information through unchanged from the source document to the destination,
+  for instance a PEF document [<a class="nref"
+  href="#ref-pef">PEF</a>]. The result document is annotated with the exact same information attached
+  to the corresponding positions in the braille.</p>
+
+<div class="example">
+  <pre>
+    &lt;obfl>
+      ...
+        &lt;block>&lt;external-reference example:key="value"/>This is some text&lt;/block>
+      ...
+    &lt;/obfl>
+  </pre>
+</div>
+
+<div class="example">
+  <pre>
+    &lt;pef>
+      ...
+        &lt;row example:key="value">⠠⠞⠓⠊⠎ ⠊⠎ ⠎⠕⠍⠑ ⠞⠑⠭⠞&lt;/row>
+      ...
+    &lt;/pef>
+  </pre>
 </div>
 
 <h4 id="L849" class="include">span</h4>
@@ -2991,6 +3018,11 @@ of this specification.</p>
       Terms for Device Independence</a>", Rhys Lewis, 18 January 2005.<br />
       <a href="http://www.w3.org/TR/di-gloss/">Latest version</a> available at:
       http://www.w3.org/TR/di-gloss/</dd>
+
+  <dt><a id="ref-pef"><strong>[PEF]</strong></a></dt>
+    <dd>"<a href="https://mtmse.github.io/pef/pef-specification.html">PEF 1.0 - Portable Embosser Format (Public draft)</a>",
+      Joel Håkansson, 12 September 2011.<br />
+      <a href="https://mtmse.github.io/pef/">Latest version</a> available at: https://mtmse.github.io/pef</dd>
   <dt><a id="ref-rfc2119"><strong>[RFC2119]</strong></a></dt>
     <dd>"<a href="http://www.ietf.org/rfc/rfc2119.txt">RFC2119: Key words for
       use in RFCs to Indicate Requirement Levels</a>", S. Bradner, March

--- a/src/obfl-specification.html
+++ b/src/obfl-specification.html
@@ -693,7 +693,7 @@ area.</p>
       group.</p>
     </dd>
   <dt>Content Model</dt>
-    <dd>block, text(), leader, marker, br, evaluate, page-number,
+    <dd>block, text(), leader, marker, br, evaluate, page-number, external-reference,
       marker-reference, span, style [0 or more]</dd>
 </dl>
 </div>
@@ -1391,7 +1391,7 @@ emphasis or strong.</p>
       </dl>
     </dd>
   <dt>Content Model</dt>
-    <dd>text(), style, marker, br, anchor, evaluate, page-number,
+    <dd>text(), style, marker, br, anchor, evaluate, page-number, external-reference,
     marker-reference [0 or more]</dd>
 </dl>
 </div>
@@ -1987,7 +1987,7 @@ volume's body of pages.</p>
     <dt>Usage</dt>
     <dd>volume-transition</dd>
     <dt>Content Model</dt>
-    <dd>text(), leader, marker, br, evaluate, page-number, marker-reference,
+    <dd>text(), leader, marker, br, evaluate, page-number, marker-reference, external-reference,
     span, style [0 or more]</dd>
   </dl>
 </div>

--- a/src/obfl-specification.html
+++ b/src/obfl-specification.html
@@ -671,7 +671,7 @@ area.</p>
       group.</p>
     </dd>
   <dt>Content Model</dt>
-    <dd>block, text(), leader, marker, br, evaluate, page-number,
+    <dd>block, text(), leader, marker, br, evaluate, page-number, external-reference,
       marker-reference, span, style [0 or more]</dd>
 </dl>
 </div>
@@ -865,7 +865,7 @@ markers are present on the indicated row.</p>
       </dl>
     </dd>
   <dt>Content Model</dt>
-    <dd class="markup">marker-reference, string, current-page, evaluate [0 or
+    <dd class="markup">marker-reference, string, current-page, external-reference, evaluate [0 or
       more]</dd>
 </dl>
 </div>
@@ -1566,7 +1566,7 @@ table spans.</p>
         and <a href="#padding-atts">Padding</a> attributes groups.</p>
     </dd>
   <dt>Content Model</dt>
-  <dd>text(), leader, marker, br, evaluate, page-number, marker-reference, span,
+  <dd>text(), leader, marker, br, evaluate, page-number, marker-reference, span, external-reference,
   style, anchor, block, xml-data [0 or more]</dd>
 </dl>
 </div>
@@ -1635,7 +1635,7 @@ volume. In a document-ranged toc-sequence, the content will always be rendered.<
       </dl>
     </dd>
   <dt>Content Model</dt>
-    <dd>text(), leader, marker, br, evaluate, page-number, marker-reference,
+    <dd>text(), leader, marker, br, evaluate, page-number, marker-reference, external-reference,
       span, style [0 or more]</dd>
 </dl>
 </div>
@@ -1680,7 +1680,7 @@ more than once. The range consists of two block ids (the latter is optional).</p
       </dl>
     </dd>
   <dt>Content Model</dt>
-    <dd>text(), leader, marker, br, evaluate, page-number, marker-reference,
+    <dd>text(), leader, marker, br, evaluate, page-number, marker-reference, external-reference,
       span, style [0 or more]</dd>
 </dl>
 </div>
@@ -2003,7 +2003,7 @@ volume's body of pages.</p>
       <dt>Usage</dt>
       <dd>volume-transition</dd>
       <dt>Content Model</dt>
-      <dd>text(), leader, marker, br, evaluate, page-number, marker-reference,
+      <dd>text(), leader, marker, br, evaluate, page-number, marker-reference, external-reference,
       span, style [0 or more]</dd>
     </dl>
   </div>
@@ -2110,7 +2110,7 @@ flow. The behavior of this element is similar to the toc-entry element.</p>
       group.</p>
     </dd>
   <dt>Content Model</dt>
-    <dd>block, text(), leader, marker, br, evaluate, page-number,
+    <dd>block, text(), leader, marker, br, evaluate, page-number, external-reference,
       marker-reference, span, style [0 or more]</dd>
 </dl>
 </div>

--- a/src/obfl-specification.html
+++ b/src/obfl-specification.html
@@ -1167,7 +1167,7 @@ should be excluded entirely.</p>
       </dl>
     </dd>
   <dt>Content Model</dt>
-    <dd>text(), leader, marker, br, evaluate, page-number, metadata, marker-reference,
+    <dd>text(), leader, marker, br, evaluate, page-number, blockmeta, marker-reference,
       span, style, anchor, block, table, xml-data [0 or more]</dd>
 </dl>
 </div>
@@ -1320,12 +1320,12 @@ element.</p>
 </dl>
 </div>
 
-<h4 id="L840" class="include">metadata</h4>
+<h4 id="L840" class="include">blockmeta</h4>
 
-<ins datetime="20200429T15:00:00">The metadata attribute can be added to any block in order
+<ins datetime="20200429T15:00:00">The blockmeta element can be attached to any position in the text within the block
   to send information through the dotify framework from obfl to pef.</ins>
 
-<p>The metadata element is used to add information.</p>
+<p>The blockmeta element is used to add information.</p>
 
 <div class="sidebar markup">
 <dl>

--- a/src/obfl-specification.html
+++ b/src/obfl-specification.html
@@ -1593,7 +1593,7 @@ table spans.</p>
         and <a href="#padding-atts">Padding</a> attributes groups.</p>
     </dd>
   <dt>Content Model</dt>
-  <dd>text(), leader, marker, br, evaluate, page-number, marker-reference, span, external-reference,
+  <dd>text(), leader, marker, br, evaluate, page-number, external-reference, marker-reference, span,
   style, anchor, block, xml-data [0 or more]</dd>
 </dl>
 </div>
@@ -1662,7 +1662,7 @@ volume. In a document-ranged toc-sequence, the content will always be rendered.<
       </dl>
     </dd>
   <dt>Content Model</dt>
-    <dd>text(), leader, marker, br, evaluate, page-number, marker-reference, external-reference,
+    <dd>text(), leader, marker, br, evaluate, page-number, external-reference, marker-reference,
       span, style [0 or more]</dd>
 </dl>
 </div>
@@ -1707,7 +1707,7 @@ more than once. The range consists of two block ids (the latter is optional).</p
       </dl>
     </dd>
   <dt>Content Model</dt>
-    <dd>text(), leader, marker, br, evaluate, page-number, marker-reference, external-reference,
+    <dd>text(), leader, marker, br, evaluate, page-number, external-reference, marker-reference,
       span, style [0 or more]</dd>
 </dl>
 </div>
@@ -2014,7 +2014,7 @@ volume's body of pages.</p>
     <dt>Usage</dt>
     <dd>volume-transition</dd>
     <dt>Content Model</dt>
-    <dd>text(), leader, marker, br, evaluate, page-number, marker-reference, external-reference,
+    <dd>text(), leader, marker, br, evaluate, page-number, external-reference, marker-reference,
     span, style [0 or more]</dd>
   </dl>
 </div>
@@ -2030,7 +2030,7 @@ volume's body of pages.</p>
       <dt>Usage</dt>
       <dd>volume-transition</dd>
       <dt>Content Model</dt>
-      <dd>text(), leader, marker, br, evaluate, page-number, marker-reference, external-reference,
+      <dd>text(), leader, marker, br, evaluate, page-number, external-reference, marker-reference,
       span, style [0 or more]</dd>
     </dl>
   </div>

--- a/src/obfl-specification.html
+++ b/src/obfl-specification.html
@@ -19,7 +19,7 @@
 <dl>
   <dt>This version:</dt>
     <dd><a
-      href="https://braillespecs.github.io/obfl/obfl-specification.html">https://braillespecs.github.io/obfl/obfl-specification.html</a></dd>
+      href="https://mtmse.github.io/obfl/obfl-specification.html">https://mtmse.github.io/obfl/obfl-specification.html</a></dd>
   <dt>Author:</dt>
     <dd>Joel Håkansson</dd>
   <dt>Contributors:</dt>

--- a/src/obfl-specification.html
+++ b/src/obfl-specification.html
@@ -1167,7 +1167,7 @@ should be excluded entirely.</p>
       </dl>
     </dd>
   <dt>Content Model</dt>
-    <dd>text(), leader, marker, br, evaluate, page-number, blockmeta, marker-reference,
+    <dd>text(), leader, marker, br, evaluate, page-number, external-reference, marker-reference,
       span, style, anchor, block, table, xml-data [0 or more]</dd>
 </dl>
 </div>
@@ -1320,12 +1320,12 @@ element.</p>
 </dl>
 </div>
 
-<h4 id="L840" class="include">blockmeta</h4>
+<h4 id="L840" class="include">external-reference</h4>
 
-<ins datetime="20200429T15:00:00">The blockmeta element can be attached to any position in the text within the block
+<ins datetime="20200429T15:00:00">The external-reference element can be attached to any position in the text within the block
   to send information through the dotify framework from obfl to pef.</ins>
 
-<p>The blockmeta element is used to add information.</p>
+<p>The external-reference element is used to add information.</p>
 
 <div class="sidebar markup">
 <dl>

--- a/src/validation/obfl.rng
+++ b/src/validation/obfl.rng
@@ -8,7 +8,7 @@
       <ref name="br"/>
       <ref name="evaluate"/>
       <ref name="page-number"/>
-      <ref name="metadata"/>
+      <ref name="blockmeta"/>
       <ref name="marker-reference"/>
       <ref name="span"/>
       <ref name="style"/>

--- a/src/validation/obfl.rng
+++ b/src/validation/obfl.rng
@@ -63,9 +63,9 @@
   -->
   <!--
     Due to the limitations in expressiveness of text-only media, the meaning of the numbers are
-    open to interpretation. 1 should be the thinnest possible value, 2 should be the double width 
-    of 1, and so on. However, if it better matches the capabilities of the border characters, 2 
-    could also mean the second thinnest possible border, and 3 the third thinnest border, and so on. 
+    open to interpretation. 1 should be the thinnest possible value, 2 should be the double width
+    of 1, and so on. However, if it better matches the capabilities of the border characters, 2
+    could also mean the second thinnest possible border, and 3 the third thinnest border, and so on.
     The default value is 1.
   -->
   <!--
@@ -704,7 +704,7 @@
   </define>
   <define name="attlist-current-page" combine="interleave">
     <optional>
-      <ref name="number-format-attribute"/>  
+      <ref name="number-format-attribute"/>
     </optional>
     <optional>
       <attribute name="text-style">
@@ -1003,7 +1003,7 @@
         <ref name="on-toc-end"/>
       </zeroOrMore>
     </element>
-  </define>  
+  </define>
   <define name="attlist-toc-sequence" combine="interleave">
     <attribute name="toc">
       <data type="IDREF"/>
@@ -1511,8 +1511,11 @@
     </element>
   </define>
   <define name="attlist-metadata" combine="interleave">
-    <attribute name="*">
-    </attribute>
+    <zeroOrMore>
+      <attribute>
+        <anyName></anyName>
+      </attribute>
+    </zeroOrMore>
   </define>
   <define name="page-number">
     <element name="page-number">
@@ -1632,7 +1635,7 @@
   <define name="attlist-xml-data" combine="interleave">
     <attribute name="renderer" >
       <data type="IDREF"/>
-    </attribute> 
+    </attribute>
   </define>
   <define name="renderer">
     <element name="renderer">
@@ -1722,7 +1725,7 @@
       </choice>
     </zeroOrMore>
   </define>
-  
+
   <define name="any_element_except_obfl">
     <element>
       <anyName><except><nsName ns="http://www.daisy.org/ns/2011/obfl"></nsName></except></anyName>
@@ -1734,22 +1737,22 @@
       <ref name="any"/>
     </element>
   </define>
-  
+
   <define name="any_content">
     <zeroOrMore>
       <choice>
         <ref name="any_element"/>
         <ref name="any_obfl"/>
         <text/>
-      </choice>        
+      </choice>
     </zeroOrMore>
   </define>
- 
+
   <define name="any_obfl">
     <documentation xmlns="http://relaxng.org/ns/compatibility/annotations/1.0">
       This definition is complex because any id/idref values defined in obfl needs to be retained using an enumerated list.
       For these elements, the id/idref attributes are retained as optional. This will work for many situations, but it will
-      fail in some cases, for example if the same id is used on two obfl elements inside different branches of an xslt choice 
+      fail in some cases, for example if the same id is used on two obfl elements inside different branches of an xslt choice
       statement.
     </documentation>
     <choice>
@@ -1849,7 +1852,7 @@
     </element>
     </choice>
   </define>
-  
+
   <define name="any_element">
     <element>
       <anyName><except><nsName ns="http://www.daisy.org/ns/2011/obfl"></nsName></except></anyName>

--- a/src/validation/obfl.rng
+++ b/src/validation/obfl.rng
@@ -1504,16 +1504,20 @@
   <define name="attlist-br" combine="interleave">
     <empty/>
   </define>
-  <define name="metadata">
-    <element name="metadata">
-      <ref name="attlist-metadata"/>
+  <define name="blockmeta">
+    <element name="blockmeta">
+      <ref name="attlist-blockmeta"/>
       <empty/>
     </element>
   </define>
-  <define name="attlist-metadata" combine="interleave">
+  <define name="attlist-blockmeta" combine="interleave">
     <zeroOrMore>
       <attribute>
-        <anyName></anyName>
+        <anyName>
+            <except>
+              <nsName ns="http://www.daisy.org/ns/2011/obfl"/>
+            </except>
+        </anyName>
       </attribute>
     </zeroOrMore>
   </define>

--- a/src/validation/obfl.rng
+++ b/src/validation/obfl.rng
@@ -8,6 +8,7 @@
       <ref name="br"/>
       <ref name="evaluate"/>
       <ref name="page-number"/>
+      <ref name="metadata"/>
       <ref name="marker-reference"/>
       <ref name="span"/>
       <ref name="style"/>
@@ -1502,6 +1503,16 @@
   </define>
   <define name="attlist-br" combine="interleave">
     <empty/>
+  </define>
+  <define name="metadata">
+    <element name="metadata">
+      <ref name="attlist-metadata"/>
+      <empty/>
+    </element>
+  </define>
+  <define name="attlist-metadata" combine="interleave">
+    <attribute name="*">
+    </attribute>
   </define>
   <define name="page-number">
     <element name="page-number">

--- a/src/validation/obfl.rng
+++ b/src/validation/obfl.rng
@@ -1515,6 +1515,7 @@
       <attribute>
         <anyName>
             <except>
+              <nsName ns=""/>
               <nsName ns="http://www.daisy.org/ns/2011/obfl"/>
             </except>
         </anyName>

--- a/src/validation/obfl.rng
+++ b/src/validation/obfl.rng
@@ -8,7 +8,7 @@
       <ref name="br"/>
       <ref name="evaluate"/>
       <ref name="page-number"/>
-      <ref name="blockmeta"/>
+      <ref name="external-reference"/>
       <ref name="marker-reference"/>
       <ref name="span"/>
       <ref name="style"/>
@@ -1504,13 +1504,13 @@
   <define name="attlist-br" combine="interleave">
     <empty/>
   </define>
-  <define name="blockmeta">
-    <element name="blockmeta">
-      <ref name="attlist-blockmeta"/>
+  <define name="external-reference">
+    <element name="external-reference">
+      <ref name="attlist-external-reference"/>
       <empty/>
     </element>
   </define>
-  <define name="attlist-blockmeta" combine="interleave">
+  <define name="attlist-external-reference" combine="interleave">
     <zeroOrMore>
       <attribute>
         <anyName>


### PR DESCRIPTION
Issue https://github.com/mtmse/dotify.formatter.impl/issues/25

Description:
Enable the addition of a metadata tag in OBFL to have it available in the PEF output.

Changes:
* Added metadata as a possible child to block.