### PR TITLE
#25: Introduced break-after attribute on sequences; added values 'page' and 'sheet' to existing break-before attributes

### DIFF
--- a/src/examples/example1.obfl
+++ b/src/examples/example1.obfl
@@ -57,6 +57,9 @@
 		</layout-master>
 		<volume-template sheets-in-volume-max="100" use-when="(= $volume 1)">
 			<post-content>
+				<sequence master="main" break-after="page">
+					<block/>
+				</sequence>
 				<dynamic-sequence master="main">
 					<list-of-references collection="notes" range="document">
 						<on-volume-start>
@@ -166,7 +169,7 @@
 				Page number within style: <style name="strong"><page-number ref-id="a"/></style>
 			</block>
 		</sequence>
-		<sequence master="rear">
+		<sequence master="rear" break-before="volume">
 			<block>This is part of a new sequence. Note that this sequence does not have an initial page number. Page numbering continues from the preceding section.</block>
 		</sequence>
 </obfl>

--- a/src/obfl-specification.html
+++ b/src/obfl-specification.html
@@ -1063,12 +1063,13 @@ the current page, using the number format specified by this element.</p>
           <dd>Specifies a translation policy.</dd>
           <dd>See the <a href="#L2462">attribute description</a> for more
             information.</dd>
-		<dt>break-before [optional]</dt>
+        <dt>break-before [optional]</dt>
           <dd class="no-markup">Inserts a break before the sequence begins.</dd>
           <dd>One of 'auto' (default), 'sheet', 'page' or 'volume'.</dd>
           <dd>See <a href="#L5024">Duplex</a> for more information.</dd>
-		<dt>break-after [optional]</dt>
-          <dd class="no-markup">Inserts a break after the sequence has ended.</dd>
+        <dt>break-after [optional]</dt>
+          <dd class="no-markup">Inserts a break after the sequence has
+            ended.</dd>
           <dd>One of 'auto' (default), 'sheet', 'page' or 'volume'.</dd>
           <dd>See <a href="#L5024">Duplex</a> for more information.</dd>
       </dl>
@@ -1114,12 +1115,13 @@ should be excluded entirely.</p>
           <dd>Specifies a translation policy.</dd>
           <dd>See the <a href="#L2462">attribute description</a> for more
             information.</dd>
-		<dt>break-before [optional]</dt>
+        <dt>break-before [optional]</dt>
           <dd class="no-markup">Inserts a break before the sequence begins.</dd>
           <dd>One of 'auto' (default), 'sheet' or 'page'.</dd>
           <dd>See <a href="#L5024">Duplex</a> for more information.</dd>
-		<dt>break-after [optional]</dt>
-          <dd class="no-markup">Inserts a break after the sequence has ended.</dd>
+        <dt>break-after [optional]</dt>
+          <dd class="no-markup">Inserts a break after the sequence has
+            ended.</dd>
           <dd>One of 'auto' (default), 'sheet' or 'page'.</dd>
           <dd>See <a href="#L5024">Duplex</a> for more information.</dd>
       </dl>
@@ -1176,21 +1178,21 @@ should be excluded entirely.</p>
           <dd class="no-markup">Inserts a break before the block begins.</dd>
         <dd>One of:
         <dl><dt>'auto' (default)</dt>
-          	<dt>'page'</dt>
-          	<dd>Insert a page break before the block.</dd>
-          	<dt>'sheet'</dt>
-          	<dd>Insert one or two page breaks before the block so that the next page is formatted as a right page.</dd>
+            <dt>'page'</dt>
+            <dd>Insert a page break before the block.</dd>
+            <dt>'sheet'</dt>
+            <dd>Insert one or two page breaks before the block so that the next page is formatted as a right page.</dd>
           </dl></dd>
         <dt>keep [optional]</dt>
           <dd>Keep rows in this block together by breaking pages early.</dd>
           <dd>One of:
           <dl><dt>'auto' (default)</dt>
-          	<dt>'page'</dt>
-          	<dd>break page early if the whole block doesn't fit on the page.</dd>
-          	<dt>'sheet'</dt>
-          	<dd>break page and sheet early if the whole block doesn't fit on the sheet.</dd>
-          	<dt>'volume'</dt>
-          	<dd>break page, sheet and volume early if the whole block doesn't fit in the volume.</dd>
+            <dt>'page'</dt>
+            <dd>break page early if the whole block doesn't fit on the page.</dd>
+            <dt>'sheet'</dt>
+            <dd>break page and sheet early if the whole block doesn't fit on the sheet.</dd>
+            <dt>'volume'</dt>
+            <dd>break page, sheet and volume early if the whole block doesn't fit in the volume.</dd>
            </dl></dd>
         <dt>keep-with-next [optional]</dt>
           <dd>Keep the following block's first line(s) on the same page as this
@@ -1864,12 +1866,13 @@ data.</p>
           <dd>Specifies a translation policy.</dd>
           <dd>See the <a href="#L2462">attribute description</a> for more
             information.</dd>
-		<dt>break-before [optional]</dt>
+        <dt>break-before [optional]</dt>
           <dd class="no-markup">Inserts a break before the sequence begins.</dd>
           <dd>One of 'auto' (default), 'sheet' or 'page'.</dd>
           <dd>See <a href="#L5024">Duplex</a> for more information.</dd>
-		<dt>break-after [optional]</dt>
-          <dd class="no-markup">Inserts a break after the sequence has ended.</dd>
+        <dt>break-after [optional]</dt>
+          <dd class="no-markup">Inserts a break after the sequence has
+            ended.</dd>
           <dd>One of 'auto' (default), 'sheet' or 'page'.</dd>
           <dd>See <a href="#L5024">Duplex</a> for more information.</dd>
       </dl>

--- a/src/obfl-specification.html
+++ b/src/obfl-specification.html
@@ -343,13 +343,56 @@ specified.</p>
 of these containers, starting from 1 each time.</p>
 
 <h3 id="L5023">Simplex</h3>
-<p class="markup">In a sequence where duplex is not enabled, only the front side of sheets are counted and paginated. 
-The back side of sheets are neither counted nor paginated.</p>
+<p class="markup">In a sequence where duplex is not enabled, only the front side
+  of sheets are counted and paginated. The back side of sheets are neither
+  counted nor paginated.</p>
 
 <h3 id="L5024">Duplex</h3>
-<p class="markup">In a sequence where duplex is enabled, both sides of sheets are counted and paginated.
-However, if the last sheet of a duplex sequence only has content on the front side, 
-the back side is counted, but not <em>paginated</em>.</p>
+<p class="markup">In a sequence where duplex is enabled, both sides of sheets
+  are counted and paginated. However, if the last sheet of a duplex sequence
+  only has content on the front side, it depends on the values of the optional
+  attributes break-before and break-after on sequence, dynamic-sequence and
+  toc-sequence whether there is a back side, and if so, whether it is counted or
+  paginated. The default behavior is that there is a back side and it is counted
+  but not <em>paginated</em>.</p>
+
+<ins datetime="20200612T15:00:00">The last page of a sequence where duplex is
+enabled, may not be paginated and may not be counted.</ins>
+<p></p>
+
+<div class="markup">The just-mentioned break-before and break-after attributes
+  insert a break before or after the sequence, respectively. Depending on the
+  specific element, some of these values are supported:
+  <dl>
+    <dt>'volume'</dt>
+      <dd>continue in a new volume with or after this sequence,
+        respectively.</dd>
+    <dt>'sheet'</dt>
+      <dd>continue on a new right-hand page with or after this sequence,
+        respectively. If this results in a page without content, don't skip the
+        header or footer. This behavior is consistent with break-before="sheet"
+        on a block.</dd>
+    <dt>'page'</dt>
+      <dd>continue on a new page with or after this sequence, respectively,
+        which may be a left-hand page. If there is a transition from duplex to
+        simplex or visa versa, or the page dimensions don't match, the current
+        or new sequence needs to start on a right-hand page.</dd>
+    <dt>'auto'</dt>
+      <dd>the default value 'auto' is like 'sheet' but leaving pages without
+          content completely blank (or absent).</dd>
+  </dl>
+</div>
+
+<p class="markup">The break-before and break-after attributes cover the cases
+  where you transition from the last sequence of the pre-content to the body
+  when the body is a resumption of a sequence in the previous volume. In cases
+  where a sequence is interrupted at the end of a volume and is followed by the
+  first sequence in the post-content, it is the break-before value of that new
+  sequence that matters. In cases where a sequence ends and is followed by a new
+  sequence, both the break-after value of the sequence that ended and the
+  break-before value of the new sequence must be taken into account: 'volume'
+  dominates over all the other values, 'sheet' dominates over 'page' and 'auto',
+  and 'page' dominates over 'auto'.</p>
 
 <h2>Page Model</h2>
 
@@ -1027,7 +1070,11 @@ the current page, using the number format specified by this element.</p>
 		<dt>break-before [optional]</dt>
           <dd class="no-markup">Inserts a break before the sequence begins.</dd>
           <dd>This property only applies to text body sequences.</dd> 
-          <dd>One of 'auto' (default), 'volume'.</dd>
+          <dd>One of 'auto' (default), 'sheet', 'page' or 'volume'.</dd>
+		<dt>break-after [optional]</dt>
+          <dd class="no-markup">Inserts a break after the sequence has ended.</dd>
+          <dd>This property only applies to text body sequences.</dd> 
+          <dd>One of 'auto', 'sheet' or 'page'.</dd>
       </dl>
     </dd>
   <dt>Content Model</dt>
@@ -1071,6 +1118,14 @@ should be excluded entirely.</p>
           <dd>Specifies a translation policy.</dd>
           <dd>See the <a href="#L2462">attribute description</a> for more
             information.</dd>
+		<dt>break-before [optional]</dt>
+          <dd class="no-markup">Inserts a break before the sequence begins.</dd>
+          <dd>This property only applies to text body sequences.</dd> 
+          <dd>One of 'sheet' or 'page'.</dd>
+		<dt>break-after [optional]</dt>
+          <dd class="no-markup">Inserts a break after the sequence has ended.</dd>
+          <dd>This property only applies to text body sequences.</dd> 
+          <dd>One of 'auto', 'sheet' or 'page'.</dd>
       </dl>
     </dd>
   <dt>Content Model</dt>
@@ -1813,6 +1868,14 @@ data.</p>
           <dd>Specifies a translation policy.</dd>
           <dd>See the <a href="#L2462">attribute description</a> for more
             information.</dd>
+		<dt>break-before [optional]</dt>
+          <dd class="no-markup">Inserts a break before the sequence begins.</dd>
+          <dd>This property only applies to text body sequences.</dd> 
+          <dd>One of 'sheet' or 'page'.</dd>
+		<dt>break-after [optional]</dt>
+          <dd class="no-markup">Inserts a break after the sequence has ended.</dd>
+          <dd>This property only applies to text body sequences.</dd> 
+          <dd>One of 'auto', 'sheet' or 'page'.</dd>
       </dl>
     </dd>
   <dt>Content Model</dt>

--- a/src/obfl-specification.html
+++ b/src/obfl-specification.html
@@ -1114,7 +1114,7 @@ should be excluded entirely.</p>
             information.</dd>
 		<dt>break-before [optional]</dt>
           <dd class="no-markup">Inserts a break before the sequence begins.</dd>
-          <dd>One of 'sheet' or 'page'.</dd>
+          <dd>One of 'auto' (default), 'sheet' or 'page'.</dd>
 		<dt>break-after [optional]</dt>
           <dd class="no-markup">Inserts a break after the sequence has ended.</dd>
           <dd>One of 'auto' (default), 'sheet' or 'page'.</dd>
@@ -1862,7 +1862,7 @@ data.</p>
             information.</dd>
 		<dt>break-before [optional]</dt>
           <dd class="no-markup">Inserts a break before the sequence begins.</dd>
-          <dd>One of 'sheet' or 'page'.</dd>
+          <dd>One of 'auto' (default), 'sheet' or 'page'.</dd>
 		<dt>break-after [optional]</dt>
           <dd class="no-markup">Inserts a break after the sequence has ended.</dd>
           <dd>One of 'auto' (default), 'sheet' or 'page'.</dd>

--- a/src/obfl-specification.html
+++ b/src/obfl-specification.html
@@ -228,7 +228,7 @@ and usually not corrected by WYSIWYG editors.</p>
 <p>White space can be introduced as a result of pretty printing. Pretty
 printing is often employed by users of XML-editors as it improves readability
 and navigability. However, it is an inexact process which makes certain
-assumtions about the XML-document. Most algorithms do not change elements that
+assumptions about the XML-document. Most algorithms do not change elements that
 evidently contain both non white space text nodes and elements. However, pretty
 printing algorithms often assume that an element that only has non-text
 children can be reformatted, even if:</p>
@@ -350,36 +350,32 @@ of these containers, starting from 1 each time.</p>
 <h3 id="L5024">Duplex</h3>
 <p class="markup">In a sequence where duplex is enabled, both sides of sheets
   are counted and paginated. However, if the last sheet of a duplex sequence
-  only has content on the front side, it depends on the values of the optional
+  only has content on the front side, it depends on the values of the
   attributes break-before and break-after on sequence, dynamic-sequence and
-  toc-sequence whether there is a back side, and if so, whether it is counted or
-  paginated. The default behavior is that there is a back side and it is counted
-  but not <em>paginated</em>.</p>
-
-<ins datetime="20200612T15:00:00">The last page of a sequence where duplex is
-enabled, may not be paginated and may not be counted.</ins>
-<p></p>
+  toc-sequence whether an extra page will be inserted so that the next sequence
+  starts at a right page, and whether that extra page is <em>paginated</em>
+  (which means that it has a page number and possibly a header and a footer).
+  The extra page is always counted. The default behavior is that an extra page
+  will be inserted which is not paginated.</p>
 
 <div class="markup">The just-mentioned break-before and break-after attributes
   insert a break before or after the sequence, respectively. Depending on the
   specific element, some of these values are supported:
   <dl>
     <dt>'volume'</dt>
-      <dd>continue in a new volume with or after this sequence,
-        respectively.</dd>
+      <dd>inserts a volume break. This value only applies to text body
+        sequences.</dd>
     <dt>'sheet'</dt>
-      <dd>continue on a new right-hand page with or after this sequence,
-        respectively. If this results in a page without content, don't skip the
-        header or footer. This behavior is consistent with break-before="sheet"
-        on a block.</dd>
+      <dd>inserts a sheet break. If this results in a page without content, it
+        is paginated.</dd>
     <dt>'page'</dt>
-      <dd>continue on a new page with or after this sequence, respectively,
-        which may be a left-hand page. If there is a transition from duplex to
-        simplex or visa versa, or the page dimensions don't match, the current
-        or new sequence needs to start on a right-hand page.</dd>
+      <dd>inserts a page break. If there is a transition from duplex to
+        simplex or visa versa, or the page dimensions don't match, then perform
+        a sheet break. The 'page' value can be used to produce media without
+        blank pages.</dd>
     <dt>'auto'</dt>
       <dd>the default value 'auto' is like 'sheet' but leaving pages without
-          content completely blank (or absent).</dd>
+        content completely blank (or absent).</dd>
   </dl>
 </div>
 
@@ -1069,12 +1065,10 @@ the current page, using the number format specified by this element.</p>
             information.</dd>
 		<dt>break-before [optional]</dt>
           <dd class="no-markup">Inserts a break before the sequence begins.</dd>
-          <dd>This property only applies to text body sequences.</dd> 
           <dd>One of 'auto' (default), 'sheet', 'page' or 'volume'.</dd>
 		<dt>break-after [optional]</dt>
           <dd class="no-markup">Inserts a break after the sequence has ended.</dd>
-          <dd>This property only applies to text body sequences.</dd> 
-          <dd>One of 'auto', 'sheet' or 'page'.</dd>
+          <dd>One of 'auto' (default), 'sheet', 'page' or 'volume'.</dd>
       </dl>
     </dd>
   <dt>Content Model</dt>
@@ -1120,12 +1114,10 @@ should be excluded entirely.</p>
             information.</dd>
 		<dt>break-before [optional]</dt>
           <dd class="no-markup">Inserts a break before the sequence begins.</dd>
-          <dd>This property only applies to text body sequences.</dd> 
           <dd>One of 'sheet' or 'page'.</dd>
 		<dt>break-after [optional]</dt>
           <dd class="no-markup">Inserts a break after the sequence has ended.</dd>
-          <dd>This property only applies to text body sequences.</dd> 
-          <dd>One of 'auto', 'sheet' or 'page'.</dd>
+          <dd>One of 'auto' (default), 'sheet' or 'page'.</dd>
       </dl>
     </dd>
   <dt>Content Model</dt>
@@ -1870,12 +1862,10 @@ data.</p>
             information.</dd>
 		<dt>break-before [optional]</dt>
           <dd class="no-markup">Inserts a break before the sequence begins.</dd>
-          <dd>This property only applies to text body sequences.</dd> 
           <dd>One of 'sheet' or 'page'.</dd>
 		<dt>break-after [optional]</dt>
           <dd class="no-markup">Inserts a break after the sequence has ended.</dd>
-          <dd>This property only applies to text body sequences.</dd> 
-          <dd>One of 'auto', 'sheet' or 'page'.</dd>
+          <dd>One of 'auto' (default), 'sheet' or 'page'.</dd>
       </dl>
     </dd>
   <dt>Content Model</dt>

--- a/src/obfl-specification.html
+++ b/src/obfl-specification.html
@@ -351,16 +351,18 @@ of these containers, starting from 1 each time.</p>
 <p class="markup">In a sequence where duplex is enabled, both sides of sheets
   are counted and paginated. However, if the last sheet of a duplex sequence
   only has content on the front side, it depends on the values of the
-  attributes break-before and break-after on sequence, dynamic-sequence and
-  toc-sequence whether an extra page will be inserted so that the next sequence
-  starts at a right page, and whether that extra page is <em>paginated</em>
-  (which means that it has a page number and possibly a header and a footer).
-  The extra page is always counted. The default behavior is that an extra page
-  will be inserted which is not paginated.</p>
+  attributes break-before and break-after on
+  <span class="markup">sequence</span>, dynamic-sequence and toc-sequence
+  whether an extra page will be inserted so that the next sequence starts at a
+  right page, and whether that extra page is <em>paginated</em> (which means
+  that it has a page number and possibly a header and a footer). The extra page
+  is always counted. The default behavior is that an extra page will be inserted
+  which is not paginated.</p>
 
-<div class="markup">The just-mentioned break-before and break-after attributes
-  insert a break before or after the sequence, respectively. Depending on the
-  specific element, some of these values are supported:
+<div>The just-mentioned break-before and break-after attributes
+  insert a break before or after the <span class="markup">sequence</span>,
+  respectively. Depending on the specific element, some of these values are
+  supported:
   <dl>
     <dt>'volume'</dt>
       <dd>inserts a volume break. This value only applies to text body
@@ -379,16 +381,14 @@ of these containers, starting from 1 each time.</p>
   </dl>
 </div>
 
-<p class="markup">The break-before and break-after attributes cover the cases
-  where you transition from the last sequence of the pre-content to the body
-  when the body is a resumption of a sequence in the previous volume. In cases
-  where a sequence is interrupted at the end of a volume and is followed by the
-  first sequence in the post-content, it is the break-before value of that new
-  sequence that matters. In cases where a sequence ends and is followed by a new
-  sequence, both the break-after value of the sequence that ended and the
-  break-before value of the new sequence must be taken into account: 'volume'
-  dominates over all the other values, 'sheet' dominates over 'page' and 'auto',
-  and 'page' dominates over 'auto'.</p>
+<p class="markup">When a sequence ends and is followed by a new sequence, both
+  the break-after value of the sequence that ended and the break-before value
+  of the new sequence must be taken into account: 'volume' dominates over all
+  the other values, 'sheet' dominates over 'page' and 'auto', and 'page'
+  dominates over 'auto'. Note that a sequence does not <em>end</em> when it is
+  interrupted by one or more post-content or pre-content sequences (i.e. at a
+  volume break), and likewise it does not <em>start</em> when it is resumed
+  in the next volume.</p>
 
 <h2>Page Model</h2>
 
@@ -1066,9 +1066,11 @@ the current page, using the number format specified by this element.</p>
 		<dt>break-before [optional]</dt>
           <dd class="no-markup">Inserts a break before the sequence begins.</dd>
           <dd>One of 'auto' (default), 'sheet', 'page' or 'volume'.</dd>
+          <dd>See <a href="#L5024">Duplex</a> for more information.</dd>
 		<dt>break-after [optional]</dt>
           <dd class="no-markup">Inserts a break after the sequence has ended.</dd>
           <dd>One of 'auto' (default), 'sheet', 'page' or 'volume'.</dd>
+          <dd>See <a href="#L5024">Duplex</a> for more information.</dd>
       </dl>
     </dd>
   <dt>Content Model</dt>
@@ -1115,9 +1117,11 @@ should be excluded entirely.</p>
 		<dt>break-before [optional]</dt>
           <dd class="no-markup">Inserts a break before the sequence begins.</dd>
           <dd>One of 'auto' (default), 'sheet' or 'page'.</dd>
+          <dd>See <a href="#L5024">Duplex</a> for more information.</dd>
 		<dt>break-after [optional]</dt>
           <dd class="no-markup">Inserts a break after the sequence has ended.</dd>
           <dd>One of 'auto' (default), 'sheet' or 'page'.</dd>
+          <dd>See <a href="#L5024">Duplex</a> for more information.</dd>
       </dl>
     </dd>
   <dt>Content Model</dt>
@@ -1863,9 +1867,11 @@ data.</p>
 		<dt>break-before [optional]</dt>
           <dd class="no-markup">Inserts a break before the sequence begins.</dd>
           <dd>One of 'auto' (default), 'sheet' or 'page'.</dd>
+          <dd>See <a href="#L5024">Duplex</a> for more information.</dd>
 		<dt>break-after [optional]</dt>
           <dd class="no-markup">Inserts a break after the sequence has ended.</dd>
           <dd>One of 'auto' (default), 'sheet' or 'page'.</dd>
+          <dd>See <a href="#L5024">Duplex</a> for more information.</dd>
       </dl>
     </dd>
   <dt>Content Model</dt>

--- a/src/validation/obfl.rng
+++ b/src/validation/obfl.rng
@@ -436,7 +436,7 @@
     master, name of master to use for this sequence
     initial-page-number, number of first page in the sequence
   -->
-  <define name="sequenceAtts">
+  <define name="textBodySequenceAtts">
     <attribute name="master">
       <data type="IDREF"/>
     </attribute>
@@ -460,6 +460,38 @@
           <value>page</value>
           <value>sheet</value>
           <value>volume</value>
+        </choice>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="page-number-counter">
+        <data type="NMTOKEN"/>
+      </attribute>
+    </optional>
+    <ref name="textAtts"/>
+  </define>
+  <define name="preAndPostContentSequenceAtts">
+    <attribute name="master">
+      <data type="IDREF"/>
+    </attribute>
+    <optional>
+      <attribute name="initial-page-number"/>
+    </optional>
+    <optional>
+      <attribute name="break-before">
+        <choice>
+          <value>auto</value>
+          <value>page</value>
+          <value>sheet</value>
+        </choice>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="break-after">
+        <choice>
+          <value>auto</value>
+          <value>page</value>
+          <value>sheet</value>
         </choice>
       </attribute>
     </optional>
@@ -1011,7 +1043,7 @@
         <value>volume</value>
       </choice>
     </attribute>
-    <ref name="sequenceAtts"/>
+    <ref name="preAndPostContentSequenceAtts"/>
   </define>
   <define name="on-toc-start">
     <element name="on-toc-start">
@@ -1169,7 +1201,7 @@
     </element>
   </define>
   <define name="attlist-dynamic-sequence" combine="interleave">
-    <ref name="sequenceAtts"/>
+    <ref name="preAndPostContentSequenceAtts"/>
   </define>
   <!-- A sequence of blocks -->
   <define name="sequence">
@@ -1185,7 +1217,7 @@
     </element>
   </define>
   <define name="attlist-sequence" combine="interleave">
-    <ref name="sequenceAtts"/>
+    <ref name="textBodySequenceAtts"/>
   </define>
   <!-- fallback-scope (all|page) #IMPLIED -->
   <define name="page-area">

--- a/src/validation/obfl.rng
+++ b/src/validation/obfl.rng
@@ -436,32 +436,12 @@
     master, name of master to use for this sequence
     initial-page-number, number of first page in the sequence
   -->
-  <define name="textBodySequenceAtts">
+  <define name="sequenceAtts-except-break-before-after">
     <attribute name="master">
       <data type="IDREF"/>
     </attribute>
     <optional>
       <attribute name="initial-page-number"/>
-    </optional>
-    <optional>
-      <attribute name="break-before">
-        <choice>
-          <value>auto</value>
-          <value>page</value>
-          <value>sheet</value>
-          <value>volume</value>
-        </choice>
-      </attribute>
-    </optional>
-    <optional>
-      <attribute name="break-after">
-        <choice>
-          <value>auto</value>
-          <value>page</value>
-          <value>sheet</value>
-          <value>volume</value>
-        </choice>
-      </attribute>
     </optional>
     <optional>
       <attribute name="page-number-counter">
@@ -470,13 +450,31 @@
     </optional>
     <ref name="textAtts"/>
   </define>
-  <define name="preAndPostContentSequenceAtts">
-    <attribute name="master">
-      <data type="IDREF"/>
-    </attribute>
+  <define name="sequenceAtts">
+    <ref name="sequenceAtts-except-break-before-after"/>
     <optional>
-      <attribute name="initial-page-number"/>
+      <attribute name="break-before">
+        <choice>
+          <value>auto</value>
+          <value>page</value>
+          <value>sheet</value>
+          <value>volume</value>
+        </choice>
+      </attribute>
     </optional>
+    <optional>
+      <attribute name="break-after">
+        <choice>
+          <value>auto</value>
+          <value>page</value>
+          <value>sheet</value>
+          <value>volume</value>
+        </choice>
+      </attribute>
+    </optional>
+  </define>
+  <define name="preAndPostContentSequenceAtts">
+    <ref name="sequenceAtts-except-break-before-after"/>
     <optional>
       <attribute name="break-before">
         <choice>
@@ -495,12 +493,6 @@
         </choice>
       </attribute>
     </optional>
-    <optional>
-      <attribute name="page-number-counter">
-        <data type="NMTOKEN"/>
-      </attribute>
-    </optional>
-    <ref name="textAtts"/>
   </define>
   <!-- Document root -->
   <define name="obfl">
@@ -916,7 +908,7 @@
       <ref name="attlist-pre-content"/>
       <zeroOrMore>
         <choice>
-          <ref name="sequence"/>
+          <ref name="sequence-in-pre-post-content"/>
           <ref name="dynamic-sequence"/>
           <ref name="toc-sequence"/>
         </choice>
@@ -931,7 +923,7 @@
       <ref name="attlist-post-content"/>
       <zeroOrMore>
         <choice>
-          <ref name="sequence"/>
+          <ref name="sequence-in-pre-post-content"/>
           <ref name="dynamic-sequence"/>
           <ref name="toc-sequence"/>
         </choice>
@@ -1217,7 +1209,22 @@
     </element>
   </define>
   <define name="attlist-sequence" combine="interleave">
-    <ref name="textBodySequenceAtts"/>
+    <ref name="sequenceAtts"/>
+  </define>
+  <define name="sequence-in-pre-post-content">
+    <element name="sequence">
+      <ref name="attlist-sequence-in-pre-post-content"/>
+      <oneOrMore>
+        <choice>
+          <ref name="block"/>
+          <ref name="table"/>
+          <ref name="xml-data"/>
+        </choice>
+      </oneOrMore>
+    </element>
+  </define>
+  <define name="attlist-sequence-in-pre-post-content" combine="interleave">
+    <ref name="preAndPostContentSequenceAtts"/>
   </define>
   <!-- fallback-scope (all|page) #IMPLIED -->
   <define name="page-area">

--- a/src/validation/obfl.rng
+++ b/src/validation/obfl.rng
@@ -447,6 +447,18 @@
       <attribute name="break-before">
         <choice>
           <value>auto</value>
+          <value>page</value>
+          <value>sheet</value>
+          <value>volume</value>
+        </choice>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="break-after">
+        <choice>
+          <value>auto</value>
+          <value>page</value>
+          <value>sheet</value>
           <value>volume</value>
         </choice>
       </attribute>


### PR DESCRIPTION
Closes #25.

@bertfrees @kalaspuffar please review this pull request

You may also have a look at this temporary available [preview](https://rambags.home.xs4all.nl/obfl/obfl-specification.html).