### PR TITLE
Adding section describing marking of capital letters attribute.

### DIFF
--- a/src/obfl-specification.html
+++ b/src/obfl-specification.html
@@ -1858,7 +1858,8 @@ data.</p>
             of the XML 1.0 Recommendation [<a class="nref"
             href="#ref-xml">XML</a>].</dd>
         <dt>hyphenate [optional]</dt>
-          <dd>Whether or not to hyphenate text descendants. </dd>
+          <dd>Whether or not to 
+		  text descendants. </dd>
           <dd>One of 'true' or 'false'.</dd>
           <dd>See the <a href="#L21839">attribute description</a> for more
             information.</dd>
@@ -2763,10 +2764,7 @@ characters):</p>
 
 <p>The overall policy for marking capital letters should be determined by the
 implementing application, for example per job or in a system setting. A user's
-preference should be respected, unless doing so would render the text difficult
-to read or interpret for some reason. The hyphenate attribute can be used when
-detailed control over hyphenation is required, e.g. to ensure proper rendering of
-content that may be difficult to interpret if capital markings are used.</p>
+preference should be respected.</p>
 
 <p>The marking of capital letters specified by <code>mark-capital-letters</code>
 applies to all elements in its content unless overridden with another instance of
@@ -2777,55 +2775,9 @@ without specifying another marking policy. Within B, the user's
 preference for marking capital letters should be applied.</p>
 
 <p>The value of the <code>mark-capital-letters</code> attribute can either be 'true' or 'false'.
-The value 'true' indicates that a text algorithm add capital markings to the
-text contents. The value 'false' indicates that a text algorithm should
+The value 'true' indicates that we add capital markings to the
+text contents. The value 'false' indicates we should
 <strong>NOT</strong> add capital markings text contents.</p>
-
-<h4 id="L2784">Example</h4>
-
-<p>The following table illustrates the output for different combinations of
-input text and capital letters marking attribute value:</p>
-
-  <table border="1" style="width: 300px">
-  <thead>
-    <tr>
-      <th>input</th>
-      <th>mark-capital-letters</th>
-      <th>output</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td rowspan="2">Example</td>
-      <td>true</td>
-      <td>_example</td>
-    </tr>
-    <tr>
-      <td>false</td>
-      <td>example</td>
-    </tr>
-    <tr>
-      <td rowspan="2">EXAMPLE</td>
-      <td>true</td>
-      <td>__example</td>
-    </tr>
-    <tr>
-      <td>false</td>
-      <td>example</td>
-    </tr>
-    <tr>
-      <td rowspan="2">THIS IS AN EXAMPLE</td>
-      <td>true</td>
-      <td>___this is an example___</td>
-    </tr>
-    <tr>
-      <td>false</td>
-      <td>this is an example</td>
-    </tr>
-  </tbody>
-</table>
-
-
 
 <h3 id="pagenumbercounter">page-number-counter</h3>
 

--- a/src/obfl-specification.html
+++ b/src/obfl-specification.html
@@ -2759,6 +2759,74 @@ characters):</p>
   </tbody>
 </table>
 
+<h3 id="L2762">mark-capital-letters</h3>
+
+<p>The overall policy for marking capital letters should be determined by the
+implementing application, for example per job or in a system setting. A user's
+preference should be respected, unless doing so would render the text difficult
+to read or interpret for some reason. The hyphenate attribute can be used when
+detailed control over hyphenation is required, e.g. to ensure proper rendering of
+content that may be difficult to interpret if capital markings are used.</p>
+
+<p>The marking of capital letters specified by <code>mark-capital-letters</code>
+applies to all elements in its content unless overridden with another instance of
+<code>mark-capital-letters</code>. In particular, the empty value of
+<code>mark-capital-letters</code> is used on an element B to override a
+specification of <code>mark-capital-letters</code> on an enclosing element A,
+without specifying another marking policy. Within B, the user's
+preference for marking capital letters should be applied.</p>
+
+<p>The value of the <code>mark-capital-letters</code> attribute can either be 'true' or 'false'.
+The value 'true' indicates that a text algorithm add capital markings to the
+text contents. The value 'false' indicates that a text algorithm should
+<strong>NOT</strong> add capital markings text contents.</p>
+
+<h4 id="L2784">Example</h4>
+
+<p>The following table illustrates the output for different combinations of
+input text and capital letters marking attribute value:</p>
+
+  <table border="1" style="width: 300px">
+  <thead>
+    <tr>
+      <th>input</th>
+      <th>mark-capital-letters</th>
+      <th>output</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td rowspan="2">Example</td>
+      <td>true</td>
+      <td>_example</td>
+    </tr>
+    <tr>
+      <td>false</td>
+      <td>example</td>
+    </tr>
+    <tr>
+      <td rowspan="2">EXAMPLE</td>
+      <td>true</td>
+      <td>__example</td>
+    </tr>
+    <tr>
+      <td>false</td>
+      <td>example</td>
+    </tr>
+    <tr>
+      <td rowspan="2">THIS IS AN EXAMPLE</td>
+      <td>true</td>
+      <td>___this is an example___</td>
+    </tr>
+    <tr>
+      <td>false</td>
+      <td>this is an example</td>
+    </tr>
+  </tbody>
+</table>
+
+
+
 <h3 id="pagenumbercounter">page-number-counter</h3>
 
   <p>Specifies a name for a page number counter to use.</p>

--- a/src/obfl-specification.html
+++ b/src/obfl-specification.html
@@ -2767,7 +2767,7 @@ text contents. The value 'false' indicates the braille translator should
 <strong>NOT</strong> add capital markings text contents.</p>
 
 <p>The overall policy for marking capital letters should be determined by the
-implementing application, for example per job or in a system setting.</p>
+implementing application or language policy, for example per job or in a system setting.</p>
 
 <p>This attribute will override that policy, using the <code>mark-capital-letters</code>
 attribute on an element tells the braille translator that this element and child elements

--- a/src/obfl-specification.html
+++ b/src/obfl-specification.html
@@ -1858,8 +1858,7 @@ data.</p>
             of the XML 1.0 Recommendation [<a class="nref"
             href="#ref-xml">XML</a>].</dd>
         <dt>hyphenate [optional]</dt>
-          <dd>Whether or not to 
-		  text descendants. </dd>
+          <dd>Whether or not to hyphenate text descendants. </dd>
           <dd>One of 'true' or 'false'.</dd>
           <dd>See the <a href="#L21839">attribute description</a> for more
             information.</dd>
@@ -2762,22 +2761,17 @@ characters):</p>
 
 <h3 id="L2762">mark-capital-letters</h3>
 
-<p>The overall policy for marking capital letters should be determined by the
-implementing application, for example per job or in a system setting. A user's
-preference should be respected.</p>
-
-<p>The marking of capital letters specified by <code>mark-capital-letters</code>
-applies to all elements in its content unless overridden with another instance of
-<code>mark-capital-letters</code>. In particular, the empty value of
-<code>mark-capital-letters</code> is used on an element B to override a
-specification of <code>mark-capital-letters</code> on an enclosing element A,
-without specifying another marking policy. Within B, the user's
-preference for marking capital letters should be applied.</p>
-
 <p>The value of the <code>mark-capital-letters</code> attribute can either be 'true' or 'false'.
-The value 'true' indicates that we add capital markings to the
-text contents. The value 'false' indicates we should
+The value 'true' indicates that the braille translator should add capital markings to the
+text contents. The value 'false' indicates the braille translator should
 <strong>NOT</strong> add capital markings text contents.</p>
+
+<p>The overall policy for marking capital letters should be determined by the
+implementing application, for example per job or in a system setting.</p>
+
+<p>This attribute will override that policy, using the <code>mark-capital-letters</code>
+attribute on an element tells the braille translator that this element and child elements
+should have another policy for marking capital letters.</p>
 
 <h3 id="pagenumbercounter">page-number-counter</h3>
 

--- a/src/validation/obfl.rng
+++ b/src/validation/obfl.rng
@@ -22,13 +22,8 @@
       <attribute name="row-spacing"/>
     </optional>
   </define>
-  <!-- hyphenate, true to hyphenate, false otherwise -->
-  <define name="textAtts">
-    <optional>
-      <attribute name="xml:lang">
-        <data type="NMTOKEN"/>
-      </attribute>
-    </optional>
+
+  <define name="textModificationAtts">
     <optional>
       <attribute name="hyphenate">
         <choice>
@@ -59,6 +54,15 @@
         </choice>
       </attribute>
     </optional>
+  </define>
+
+  <define name="textAtts">
+    <optional>
+      <attribute name="xml:lang">
+        <data type="NMTOKEN"/>
+      </attribute>
+    </optional>
+    <ref name="textModificationAtts" />
   </define>
   <define name="name-id">
     <attribute name="name">
@@ -549,36 +553,7 @@
     <attribute name="xml:lang">
       <data type="NMTOKEN"/>
     </attribute>
-    <optional>
-      <attribute name="hyphenate">
-        <choice>
-          <value>true</value>
-          <value>false</value>
-          <value></value>
-        </choice>
-      </attribute>
-    </optional>
-    <optional>
-      <attribute name="mark-capital-letters">
-        <choice>
-          <value>true</value>
-          <value>false</value>
-          <value></value>
-        </choice>
-      </attribute>
-    </optional>
-    <optional>
-      <attribute name="translate">
-        <choice>
-          <value></value>
-          <value>pre-translated</value>
-          <value>grade0</value>
-          <value>grade1</value>
-          <value>grade2</value>
-          <value>grade3</value>
-        </choice>
-      </attribute>
-    </optional>
+    <ref name="textModificationAtts" />
   </define>
   <!---->
   <define name="meta">

--- a/src/validation/obfl.rng
+++ b/src/validation/obfl.rng
@@ -39,6 +39,15 @@
       </attribute>
     </optional>
     <optional>
+      <attribute name="mark-capital-letters">
+        <choice>
+          <value>true</value>
+          <value>false</value>
+          <value></value>
+        </choice>
+      </attribute>
+    </optional>
+    <optional>
       <attribute name="translate">
         <choice>
           <value></value>
@@ -542,6 +551,15 @@
     </attribute>
     <optional>
       <attribute name="hyphenate">
+        <choice>
+          <value>true</value>
+          <value>false</value>
+          <value></value>
+        </choice>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="mark-capital-letters">
         <choice>
           <value>true</value>
           <value>false</value>


### PR DESCRIPTION
Hi @bertfrees and @PaulRambags

This pull request describes the functionality of a new attribute for text processing. `mark-capital-letters` could be used to inform the formatter if the text should have capital letter marks.

Please review and comment.

Best regards