### PR TITLE
Improve/correct documentation of `translate`, `xml:lang`, `hyphenate` and `style`

### DIFF
--- a/src/examples/example1.obfl
+++ b/src/examples/example1.obfl
@@ -144,6 +144,10 @@
 			<block>This heading is so important, that it has to start on a new page.</block>
 			<block margin-top="2" margin-bottom="1">New line</block>
 			<block>You can break a line<br/>wherever<br/>you<br/>want.</block>
+			<block translate=""/>
+			<block translate="grade:1.5"/>
+			<block translate="uncontracted/6-dot"/>
+			<block translate="grade:2/8-dot"/>
 			<!-- 
 			<float-item name="note1">
 				<block text-indent="3" margin-top="2">1<leader position="3"/>This is a note. It will be placed at the bottom of the page.</block>

--- a/src/obfl-specification.html
+++ b/src/obfl-specification.html
@@ -458,6 +458,8 @@ the text body area so that the margin area can be used as well.</p>
             href="http://www.w3.org/TR/REC-xml/#sec-lang-tag">Section 2.12</a>
             of the XML 1.0 Recommendation [<a class="nref"
             href="#ref-xml">XML</a>].</dd>
+          <dd>See the <a href="#L2500">attribute description</a> for more
+            information.</dd>
         <dt>hyphenate [optional]</dt>
           <dd>Whether or not to hyphenate text descendants. </dd>
           <dd>One of 'true' or 'false'.</dd>
@@ -854,7 +856,7 @@ markers are present on the indicated row.</p>
             length of the translated <span class="no-markup">string</span> must
             not exceed the width of the margin-region.</dd>
         <dt>text-style [optional]</dt>
-          <dd class="">A text style, e.g. emphasis or strong</dd>
+          <dd class="">A text style</dd>
       </dl>
     </dd>
   <dt>Content Model</dt>
@@ -904,7 +906,7 @@ markers are present on the indicated row.</p>
   <dt>Attributes</dt>
     <dd><dl>
         <dt>text-style [optional]</dt>
-          <dd class="">A text style, e.g. emphasis or strong</dd>
+          <dd class="">A text style</dd>
         <dt>allow-text-flow [optional]</dt>
           <dd class="">Whether text from the page body is allowed to flow into
             this field when the effective contents of the field is empty space
@@ -943,7 +945,7 @@ element. If no reference is found, the empty string is returned.</p>
           <dd>Offset the search by the specified number of pages.</dd>
           <dd>Default is 0</dd>
         <dt>text-style [optional]</dt>
-          <dd class="">A text style, e.g. emphasis or strong</dd>
+          <dd class="">A text style</dd>
           <dd class="markup note">This attribute is only available in the
           context of a field element.</dd>
       </dl>
@@ -1034,7 +1036,7 @@ value attribute.</p>
         <dt>value [required]</dt>
           <dd class="no-markup">The string to output</dd>
         <dt>text-style [optional]</dt>
-          <dd class="">A text style, e.g. emphasis or strong</dd>
+          <dd class="">A text style</dd>
       </dl>
     </dd>
   <dt>Content Model</dt>
@@ -1057,7 +1059,7 @@ the current page, using the number format specified by this element.</p>
           <dd>One of 'default', 'roman', 'upper-roman', 'lower-roman',
             'upper-alpha', 'lower-alpha'.</dd>
         <dt>text-style [optional]</dt>
-          <dd class="">A text style, e.g. emphasis or strong</dd>
+          <dd class="">A text style</dd>
       </dl>
     </dd>
   <dt>Content Model</dt>
@@ -1090,6 +1092,8 @@ the current page, using the number format specified by this element.</p>
             href="http://www.w3.org/TR/REC-xml/#sec-lang-tag">Section 2.12</a>
             of the XML 1.0 Recommendation [<a class="nref"
             href="#ref-xml">XML</a>].</dd>
+          <dd>See the <a href="#L2500">attribute description</a> for more
+            information.</dd>
         <dt>hyphenate [optional]</dt>
           <dd>Whether or not to hyphenate text descendants. </dd>
           <dd>One of 'true' or 'false'.</dd>
@@ -1142,6 +1146,8 @@ should be excluded entirely.</p>
             href="http://www.w3.org/TR/REC-xml/#sec-lang-tag">Section 2.12</a>
             of the XML 1.0 Recommendation [<a class="nref"
             href="#ref-xml">XML</a>].</dd>
+          <dd>See the <a href="#L2500">attribute description</a> for more
+            information.</dd>
         <dt>hyphenate [optional]</dt>
           <dd>Whether or not to hyphenate text descendants. </dd>
           <dd>One of 'true' or 'false'.</dd>
@@ -1311,7 +1317,7 @@ information.</p>
           <dd>A valid <a href="obfl-evaluation-language.html">OBFL Evaluation
             Language</a> expression.</dd>
         <dt>text-style [optional]</dt>
-          <dd>A text style, e.g. emphasis or strong</dd>
+          <dd>A text style</dd>
           <dd class="markup note">This attribute is only available in the context of a field element.</dd>
       </dl>
     </dd>
@@ -1556,6 +1562,8 @@ language is different from the surrounding text.</p>
             href="http://www.w3.org/TR/REC-xml/#sec-lang-tag">Section 2.12</a>
             of the XML 1.0 Recommendation [<a class="nref"
             href="#ref-xml">XML</a>].</dd>
+          <dd>See the <a href="#L2500">attribute description</a> for more
+            information.</dd>
         <dt>hyphenate [optional]</dt>
           <dd>Whether or not to hyphenate text descendants. </dd>
           <dd>One of 'true' or 'false'.</dd>
@@ -1574,8 +1582,12 @@ language is different from the surrounding text.</p>
 
 <h4 id="L8491" class="include">style</h4>
 
-<p>The style element represents a segment of text with a specific style, e.g.
-emphasis or strong.</p>
+<p>The style element represents a segment of text with specific properties. An
+example of a text property is emphasis. An important precondition for a text
+property to be a style is that it could never apply to the whole document, only
+to a portion of it.</p>
+
+<p>Note that OBFL does not impose a certain vocabulary or syntax for styles.</p>
 
 <div class="sidebar markup">
 <dl>
@@ -1916,6 +1928,8 @@ data.</p>
             href="http://www.w3.org/TR/REC-xml/#sec-lang-tag">Section 2.12</a>
             of the XML 1.0 Recommendation [<a class="nref"
             href="#ref-xml">XML</a>].</dd>
+          <dd>See the <a href="#L2500">attribute description</a> for more
+            information.</dd>
         <dt>hyphenate [optional]</dt>
           <dd>Whether or not to hyphenate text descendants. </dd>
           <dd>One of 'true' or 'false'.</dd>
@@ -2749,27 +2763,32 @@ reference content is an XSLT document. However additional content might be suppo
 <p>The overall hyphenation policy should be determined by the implementing
 application, for example per job or in a system setting. A user's preference
 should be respected, unless doing so would render the text difficult to read or
-interpret for some reason. The hyphenate attribute can be used when detailed
-control over hyphenation is required, e.g. to ensure proper rendering of
-content that may be difficult to interpret if hyphenated, such as
+interpret for some reason. The <code>hyphenate</code> attribute can be used
+when detailed control over hyphenation is required, e.g. to ensure proper
+rendering of content that may be difficult to interpret if hyphenated, such as
 hyperlinks.</p>
 
-<p>The hyphenation specified by <code>hyphenate</code> applies to all elements in
-its content unless overridden with another instance of <code>hyphenate</code>. In
-particular, the empty value of <code>hyphenate</code> is used on an element B to
-override a specification of <code>hyphenate</code> on an enclosing element A,
-without specifying another hyphenation policy. Within B, the user's
-preference for hyphenation should be applied.</p>
+<p>Note that the hyphenation policy in general does not affect the braille
+transcription itself, only how the braille is presented on the page, more
+specifically how it is "wrapped" across lines. An exception is when
+hyphenation is "non-standard".</p>
 
-<p>The value of the hyphenate attribute can either be 'true' or 'false'. The
-value 'true' indicates that a hyphenation algorithm should be applied to the
-text contents, i.e. add hyphenation information to the text. The value 'false'
-indicates that a hyphenation algorithm should <strong>NOT</strong> be applied
-to the text contents. However, obvious hyphention points that were already in
-the text to begin with <em>may</em> be used to hyphenate. Examples of
+<p>The hyphenation policy specified by <code>hyphenate</code> applies to all
+elements in its content unless overridden with another instance of <code
+>hyphenate</code>. In particular, the empty value of <code>hyphenate</code>
+is used on an element B to override a specification of <code>hyphenate</code>
+on an enclosing element A, without specifying another hyphenation policy.
+Within B, the user's preference for hyphenation should be applied.</p>
+
+<p>The value of the <code>hyphenate</code> attribute can either be 'true' or
+'false'. The value 'true' indicates that a hyphenation algorithm should be
+applied to the text contents, i.e. add hyphenation information to the text. The
+value 'false' indicates that a hyphenation algorithm should <strong>NOT</strong>
+be applied to the text contents. However, obvious hyphention points that were
+already in the text to begin with <em>may</em> be used to hyphenate. Examples of
 hyphenation points that may be used to hyphenate even when the value of the
-hyphenate attribute is 'false' include (but are not limited to): SOFT HYPHEN
-(U+00AD) and ZERO WIDTH SPACE (U+200B).</p>
+<code>hyphenate</code> attribute is 'false' include (but are not limited to):
+SOFT HYPHEN (U+00AD) and ZERO WIDTH SPACE (U+200B).</p>
 
 <h4 id="L21851">Example</h4>
 
@@ -2886,34 +2905,45 @@ render a spacing equal to four row heights.</p>
 
 <h3 id="L2462">translate</h3>
 
-<p>The overall translation policy should be determined by the user of the
-application, for example as a job parameter or a system setting. A user's
-preference should be respected whenever possible. Setting the translate
-attribute on the obfl-element is generally not recommended. The translate
-attribute should be used when detailed control over translation is
-<b>required</b>, e.g. when combining different languages or in books about
-braille code.</p>
+<p>The main braille code (the rules for transcribing text to braille) should be
+determined by the user of the application, for example as a job parameter or a
+system setting. A user's preference should be respected whenever possible.
+Setting the <code>translate</code> attribute on the <code>obfl</code> element
+is generally not recommended. The <code>translate</code> attribute should be
+used when detailed control over braille transcription is <b>required</b>, e.g.
+when combining different languages or in books about braille code.</p>
 
-<p>The value of the translate attribute can be 'pre-translated', 'grade0',
-'grade1', 'grade2' or 'grade3'.</p>
+<p>The braille code specified by <code>translate</code> applies to all elements
+in its content unless overridden with another instance of <code
+>translate</code>. In particular, the empty value of <code>translate</code> is
+used on an element B to override a specification of <code>translate</code> on an
+enclosing element A, without specifying another braille code. Within B, the
+user's preference for braille transcription should be applied.</p>
 
-<p>The translation specified by <code>translate</code> applies to all elements in
-its content unless overridden with another instance of <code>translate</code>. In
-particular, the empty value of <code>translate</code> is used on an element B to
-override a specification of <code>translate</code> on an enclosing element A,
-without specififying another translation. Within B, the user's preference for
-translation should be applied.</p>
+<p>The value of the <code>translate</code> attribute can be 'contracted',
+'uncontracted', 'pre-translated', 'grade:<em>&lt;number&gt;</em>', '6-dot',
+'8-dot', or certain combinations of these values.</p>
 
-<h4 id="L2475">pre-translated</h4>
+<h4 id="L2465">contracted</h4>
+
+<p>The value 'contracted' indicates that a braille code must be applied that
+uses contractions (if applicable).</p>
+
+<h4 id="L2468">uncontracted</h4>
+
+<p>The value 'uncontracted' indicates that a braille code must be applied that
+does not use contractions.</p>
+
+<h4 id="L2471">pre-translated</h4>
 
 <p>The value 'pre-translated' indicates that <i>the contents is already
-braille</i> and hence does not need processing by a complete braille translator
-to produce braille output. When using this value, text nodes MUST contain a
-combination of braille characters [U+2800-U+28FF] and the following:</p>
+braille</i> and hence does not need to be transcribed to produce braille output.
+When using this value, text nodes MUST contain a combination of braille
+characters [U+2800-U+28FF] and the following:</p>
 <dl>
-  <dt>SPACE (U+0020)</dt>
-    <dd>Regular space MUST be used at word boundaries for the purpose of line
-      breaking.</dd>
+  <dt>White space characters</dt>
+  <dd>All characters defined as white space by <a href="#ref-unicode"
+    >[Unicode]</a>.</dd>
   <dt>SOFT HYPHEN (U+00AD)</dt>
     <dd>Soft hyphen is used for dynamically inserting a hyphen at the end of a
       line. Regular hyphens can be represented by a braille pattern followed by
@@ -2925,14 +2955,72 @@ combination of braille characters [U+2800-U+28FF] and the following:</p>
 
 <p>Note that:</p>
 <ul>
-  <li>BRAILLE PATTERN BLANK (U+2800) is not whitespace nor line breaking. It
-    can be used in place of NO-BREAK SPACE (U+00A0). For other purposes, use
-    U+0020</li>
+  <li>BRAILLE PATTERN BLANK (U+2800) is not regarded as white space and should
+    be preserved. Proper white space characters must be used at word boundaries
+    in order to achieve correct line breaking.</li>
   <li>pre-translated text nodes are not influenced by the hyphenate attribute
     nor the global hyphenation policy</li>
   <li class="markup">style elements MUST NOT occur in pre-translated
   context</li>
 </ul>
+
+<h4 id="L2479">grade:<em>&lt;number&gt;</em></h4>
+
+<p>The value 'grade:<em>&lt;number&gt;</em>', where <em>&lt;number&gt;</em> is a
+non-negative integer or decimal number, indicates that a braille code must be
+applied with the specific contraction grade identified by the number. Note that
+how contraction grades are numbered is region dependent.</p>
+
+<h4 id="L2483">6-dot</h4>
+
+<p>The value '6-dot' indicates that a braille code must be used that does not
+make use of dots 7 and 8.</p>
+
+<h4 id="L2487">8-dot</h4>
+
+<p>The value '6-dot' indicates that a braille code must be used that does makes
+use of dots 7 and 8.</p>
+
+<h4 id="L2491">Combinations</h4>
+
+<p>Combinations of above values can be made by concatenating them, with a '/'
+character as delimiter. Not all combinations are valid however, and the parts
+must appear in a specific order. The combination must exist of one or more of
+the following, in the given order:</p>
+
+<ul>
+  <li>'contracted' or 'uncontracted'</li>
+  <li>grade:<em>&lt;number&gt;</em></li>
+  <li>'6-dot' or '8-dot'</li>
+</ul>
+
+<p>Some examples:</p>
+
+<ul>
+  <li>grade:1.5</li>
+  <li>uncontracted/6-dot</li>
+  <li>grade:2/8-dot</li>
+</ul>
+
+<h3 id="L2500">xml:lang</h3>
+
+<p>The <code>xml:lang</code> attribute is used to specify the language in which
+the content is written. It does <strong>NOT</strong> imply association with a
+particular braille code (this is the role of the <a href="#L2462"><code
+>translate</code></a> attribute). A braille code may however have special rules
+for transcribing text written in another language than its "principal"
+language.</p>
+
+<p>The language specified by <code>xml:lang</code> applies to all elements in
+its content unless overridden with another instance of <code>xml:lang</code>.
+In particular, the empty value of <code>xml:lang</code> is used on an element B
+to override a specification of <code>xml:lang</code> on an enclosing element A,
+without specifying another language. Within B, it is considered that there is
+no language information available, just as if <code>xml:lang</code> had not
+been specified on B or any of its ancestors.</p>
+
+<p>The values of the attribute are language identifiers as defined by
+[<a class="nref" href="#ref-bcp47">BCP 47</a>].</p>
 
 <h2 id="L16081">Attribute Groups</h2>
 
@@ -3020,6 +3108,8 @@ combination of braille characters [U+2800-U+28FF] and the following:</p>
     <dd>the language of text descendants as defined in <a
       href="http://www.w3.org/TR/REC-xml/#sec-lang-tag">Section 2.12</a> of the
       XML 1.0 Recommendation [<a class="nref" href="#ref-xml">XML</a>].</dd>
+    <dd>See the <a href="#L2500">attribute description</a> for more
+      information.</dd>
   <dt>hyphenate [optional]</dt>
     <dd>Whether or not to hyphenate text descendants. </dd>
     <dd>One of 'true' or 'false'.</dd>
@@ -3285,6 +3375,11 @@ of this specification.</p>
     <dd>"<a href="http://www.ietf.org/rfc/rfc2119.txt">RFC2119: Key words for
       use in RFCs to Indicate Requirement Levels</a>", S. Bradner, March
     1997.</dd>
+  <dt><a id="ref-bcp47"><strong>[BCP 47]</strong></a></dt>
+    <dd>BCP 47, consisting of "<a href="https://tools.ietf.org/html/rfc4646">RFC
+    4646: Tags for Identifying Languages</a>", and
+    "<a href="https://tools.ietf.org/html/rfc4647">RFC 4647: Matching of Language
+    Tags</a>", A. Phillips, M. Davis. 2006.</dd>
   <dt><a id="ref-unicode"><strong>[Unicode]</strong></a></dt>
     <dd>"<a href="http://www.unicode.org/versions/Unicode5.1.0/">Unicode
       Standard, Version 5.1.0</a>", The Unicode Consortium. The Unicode

--- a/src/validation/obfl.rng
+++ b/src/validation/obfl.rng
@@ -23,6 +23,29 @@
       <attribute name="row-spacing"/>
     </optional>
   </define>
+  <define name="translate">
+    <optional>
+      <attribute name="translate">
+        <choice>
+          <value></value>
+          <value>pre-translated</value>
+          <value>uncontracted</value>
+          <value>contracted</value>
+          <data type="string">
+            <param name="pattern">grade:[1-9]+(\.[0-9]+)?</param>
+          </data>
+          <value>6-dot</value>
+          <value>8-dot</value>
+          <data type="token">
+            <param name="pattern">(contracted|uncontracted)(/grade:[1-9]+(\.[0-9]+)?)?(/([68]-dot))?</param>
+          </data>
+          <data type="token">
+            <param name="pattern">grade:[1-9]+(\.[0-9]+)?(/([68]-dot))?</param>
+          </data>
+        </choice>
+      </attribute>
+    </optional>
+  </define>
   <!-- hyphenate, true to hyphenate, false otherwise -->
   <define name="textAtts">
     <optional>
@@ -39,18 +62,7 @@
         </choice>
       </attribute>
     </optional>
-    <optional>
-      <attribute name="translate">
-        <choice>
-          <value></value>
-          <value>pre-translated</value>
-          <value>grade0</value>
-          <value>grade1</value>
-          <value>grade2</value>
-          <value>grade3</value>
-        </choice>
-      </attribute>
-    </optional>
+    <ref name="translate"/>
   </define>
   <define name="name-id">
     <attribute name="name">
@@ -550,18 +562,7 @@
         </choice>
       </attribute>
     </optional>
-    <optional>
-      <attribute name="translate">
-        <choice>
-          <value></value>
-          <value>pre-translated</value>
-          <value>grade0</value>
-          <value>grade1</value>
-          <value>grade2</value>
-          <value>grade3</value>
-        </choice>
-      </attribute>
-    </optional>
+    <ref name="translate"/>
   </define>
   <!---->
   <define name="meta">


### PR DESCRIPTION
- Use the terms "braille code" and "braille transcription" instead of
  "translation policy" in the documentation of the "translate"
  attribute.
- Update the allowed values for the "translate" attribute according to
  Dotify's "TranslatorMode" class. Fixes
  https://github.com/braillespecs/obfl/issues/83.
- Also update the validation of the "translate" attribute.
- Make some corrections to the documentation of the "pre-translated"
  value, notably regarding white space processing.
- Add a section dedicated to the "xml:lang" attribute.
- Add a note about non-standard hyphenation in the documentation of
  the "hyphenate" attribute.
- Add more documentation for the "style" element.